### PR TITLE
WIP: Feature/config home collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ docs
 inst/doc
 dev
 !dev/Makefile
+!dev/extract_irods_services_yaml.R
 *.irods
 /doc/
 /Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     stats,
     testthat (>= 3.0.0),
     utils,
-    withr
+    withr,
+    yaml
 Suggests: 
     httptest2,
     kableExtra,

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -42,10 +42,15 @@ iauth <- function(user, password = NULL, role = "rodsuser") {
   # add additional server information to config file
   irods_conf_file <- path_to_irods_conf()
   server_info <- jsonlite::fromJSON(irods_conf_file)
+  new_server_info <- get_server_info(FALSE)
+  .rirods$zone <- new_server_info$irods_zone
+  server_info$irods_home <- make_irods_home()
 
-  if (length(server_info) == 1) {
+  missing_info <- (!names(new_server_info) %in% names(server_info))
+
+  if (sum(missing_info) > 0) {
     export <-
-      jsonlite::toJSON(append(server_info , get_server_info(FALSE)),
+      jsonlite::toJSON(append(server_info, new_server_info[missing_info]),
                        auto_unbox = TRUE,
                        pretty = TRUE)
     write(export, file = irods_conf_file)
@@ -53,10 +58,11 @@ iauth <- function(user, password = NULL, role = "rodsuser") {
 
   # starting dir as admin or user
   .rirods$user_role <- role
-  .rirods$current_dir <- make_irods_base_path()
+  .rirods$current_dir <- server_info$irods_home
 
   invisible(NULL)
 }
+
 
 get_token <- function(user, password, host) {
 

--- a/R/collections.R
+++ b/R/collections.R
@@ -89,7 +89,7 @@ irm_ <- function(endpoint, args, verbose) {
 #' instead of a local directory.
 #'
 #' @param logical_path Path to the collection to create, relative to the current
-#'   working directory (see [ipwd()]).
+#'   working collection (see [ipwd()]).
 #' @param create_parent_collections Whether parent collections should be created
 #'   when necessary. Defaults to `FALSE`.
 #' @param overwrite Whether the existing collection should be overwritten

--- a/R/create-irods.R
+++ b/R/create-irods.R
@@ -9,6 +9,9 @@
 #' it follows platform conventions (see also [rappdirs::user_config_dir()]).
 #'
 #' @param host URL of host.
+#' @param irods_home Path to the initial working directory. Once the user is authenticated,
+#'   if no other absolute or relative path has been requested here, it will default
+#'   to `/zoneName/home`.
 #' @param zone_path Deprecated
 #' @param overwrite Overwrite existing iRODS configuration file. Defaults to
 #'    `FALSE`.
@@ -16,7 +19,7 @@
 #' @return Invisibly, the path to the iRODS configuration file.
 #' @export
 #'
-create_irods <- function(host, zone_path = character(1), overwrite = FALSE) {
+create_irods <- function(host, irods_home = character(0), zone_path = character(1), overwrite = FALSE) {
 
   if (!missing("zone_path"))
     warning("Argument `zone_path` is deprecated")
@@ -34,7 +37,7 @@ create_irods <- function(host, zone_path = character(1), overwrite = FALSE) {
   # create file
   file.create(path)
   write(
-    jsonlite::toJSON(list(host = host), auto_unbox = TRUE, pretty = TRUE),
+    jsonlite::toJSON(list(host = host, irods_home = irods_home), auto_unbox = TRUE, pretty = TRUE),
     file = path
   )
 

--- a/R/create-irods.R
+++ b/R/create-irods.R
@@ -9,7 +9,7 @@
 #' it follows platform conventions (see also [rappdirs::user_config_dir()]).
 #'
 #' @param host URL of host.
-#' @param irods_home Path to the initial working directory. Once the user is authenticated,
+#' @param irods_home Path to the initial working collection. Once the user is authenticated,
 #'   if no other absolute or relative path has been requested here, it will default
 #'   to `/zoneName/home`.
 #' @param zone_path Deprecated

--- a/R/docker-yaml.R
+++ b/R/docker-yaml.R
@@ -1,0 +1,26 @@
+get_docker_compose_path <- function() {
+  system.file("irods_demo/docker-compose.yml", package = "rirods")
+}
+
+get_docker_yaml <- function() {
+  docker_compose_file <- yaml::read_yaml(get_docker_compose_path(), handlers = list(
+    # make sure that sequences of size one are read as list
+    # (defaults to vector of length one)
+    seq = function(x) {
+      x <- as.list(x)
+      x
+    }
+  ))
+}
+
+is_irods_service_in_yaml <- function(services, docker_compose_file) {
+  docker_compose_service_names <- names(docker_compose_file[["services"]])
+  irods_services_pattern <- paste0(services, collapse = "|")
+  grepl(irods_services_pattern, docker_compose_service_names)
+}
+
+extract_irods_services_names <- function(services) {
+  docker_compose_file <- get_docker_yaml()
+  list(names(docker_compose_file[["services"]])[is_irods_service_in_yaml(services, docker_compose_file)]) |>
+    setNames(docker_compose_file[["name"]])
+}

--- a/R/irods-demo.R
+++ b/R/irods-demo.R
@@ -262,7 +262,7 @@ check_docker <- function(verbose = TRUE) {
   !(Sys.which("bash") == "" || Sys.which("docker") == "" || docker_version == "")
 }
 
-irods_containers_ref <- function(services = c("nginx", "http-api", "icommands", "catalog")) {
+irods_containers_ref <- function(services = c("nginx", "http-api", "icommands", "catalog", "minio")) {
   docker_compose_service_names = extract_irods_services_names(services)
   paste0(names(docker_compose_service_names), "-", docker_compose_service_names[[1]], "-1")
 }
@@ -273,7 +273,8 @@ irods_images <- c(
   "irods-demo-irods-catalog-provider",
   "irods-demo-irods-client-icommands",
   "irods-demo-nginx-reverse-proxy",
-  "irods/irods_http_api"
+  "irods/irods_http_api",
+  "irods-demo-minio"
 )
 
 #' Launch iRODS from Alternative Directory

--- a/R/irods-path.R
+++ b/R/irods-path.R
@@ -33,11 +33,8 @@ get_absolute_lpath <- function(lpath, write = FALSE, safely = TRUE) {
   }
 
   if (isTRUE(safely)) {
-    if (isTRUE(write)) {
-      is_lpath <- lpath_exists(strsplit(ipwd(), lpath)[[1]])
-    } else {
-      is_lpath <- lpath_exists(lpath)
-    }
+    path_to_check <- if (isTRUE(write)) strsplit(ipwd(), lpath)[[1]] else lpath
+    is_lpath <- lpath_exists(path_to_check, write=TRUE) # with write=FALSE we have a loop
     if (!is_lpath) {
       stop("Logical path [", lpath,"] is not accessible.", call. = FALSE)
     }

--- a/R/irods-path.R
+++ b/R/irods-path.R
@@ -1,23 +1,28 @@
-make_irods_base_path <- function() {
-  check_irods_conf()
-  if (!is.null(find_irods_file("irods_zone"))) {
-    if (.rirods$user_role == "rodsuser") {
-      paste0("/", find_irods_file("irods_zone"), "/home/", .rirods$user)
-    } else if (.rirods$user_role == "groupadmin") {
-      paste0("/", find_irods_file("irods_zone"), "/home")
-    } else if (.rirods$user_role == "rodsadmin") {
-      paste0("/", find_irods_file("irods_zone"))
-    } else {
-      stop("User role unknown.", call. = FALSE)
-    }
+make_irods_home <- function() {
+  irods_home <- find_irods_file("irods_home")
+  zone <- make_irods_base_path()
 
+  if (length(irods_home) == 0) {
+    return(zone)
+  }
+
+  if (!startsWith(irods_home, zone)) {
+    irods_home <- paste0(zone, gsub("^/?(.+)/?", "/\\1", irods_home))
+  }
+
+  if (lpath_exists(irods_home)) {
+    irods_home
   } else {
-    stop("iRODS zone unknown.", call. = FALSE)
+    warning(sprintf("%s does not exist, defaulting to %s", irods_home, base_home))
+    zone
   }
 }
 
-get_absolute_lpath <- function(lpath, write = FALSE, safely = TRUE) {
+make_irods_base_path <- function() {
+  sprintf("/%s/home", .rirods$zone)
+}
 
+get_absolute_lpath <- function(lpath, write = FALSE, safely = TRUE) {
   if (!grepl("^/" , lpath)) {
     # default zone_path writable by user
     zpath <- ipwd()

--- a/R/irods-path.R
+++ b/R/irods-path.R
@@ -85,7 +85,7 @@ lpath_exists <- function(lpath, write = FALSE) {
   if (!is_connected_irods()) stop("Not connected to iRODS.", call. = FALSE)
 
   # reference paths
-  all_lpaths <- ils(make_irods_base_path(), recurse = 1) |>
+  all_lpaths <- ils(make_irods_base_path(), recurse = 1, limit=NULL) |>
     as.data.frame() |>
     rbind(make_irods_base_path())
 

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -1,12 +1,12 @@
-#' Get or Set Current Working Directory in iRODS
+#' Get or Set Current Working Directory (Collection) in iRODS
 #'
 #' `ipwd()` and `icd()` are the iRODS equivalents of [getwd()] and [setwd()]
 #' respectively. For example, whereas `getwd()` returns the current working directory
-#' in the local system, `ipwd()` returns the current working directory in iRODS.
+#' in the local system, `ipwd()` returns the current working collection in iRODS.
 #'
-#' @param dir Collection to set as working directory.
+#' @param dir Path to set as working collection.
 #'
-#' @return Invisibly the current directory before the change (same convention as
+#' @return Invisibly the current collection before the change (same convention as
 #'  `setwd()`).
 #' @seealso
 #'  [setwd()] and [getwd()] for R equivalents,

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -222,8 +222,15 @@ ils <- function(
 
   irods_zone_overview <- data.frame(logical_path = lpaths)
 
-  if (isTRUE(stat)) {
+  if (isTRUE(stat) | isTRUE(permissions)) {
     ils_stat_dataframe <- make_ils_stat(irods_zone_overview$logical_path)
+    if (isFALSE(stat)) {
+      permissions_columns <- names(ils_stat_dataframe)[grepl("permission", names(ils_stat_dataframe))]
+      if ("inheritance_enabled" %in% names(ils_stat_dataframe)) {
+        permissions_columns <- c(permissions_columns, "inheritance_enabled")
+      }
+      ils_stat_dataframe <- ils_stat_dataframe[permissions_columns]
+    }
     irods_zone_overview <- cbind(irods_zone_overview, ils_stat_dataframe)
   }
 

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -140,7 +140,7 @@ ipwd <- function() .rirods$current_dir
 #' @param recurse Recursively list. Defaults to `FALSE`.
 #' @param ticket A valid iRODS ticket string. Defaults to `NULL`.
 #' @param message Show message when empty collection. Default to `FALSE`.
-#' @param limit Number of records to show per page.
+#' @param limit Number of records to show. To show all records, provide `NULL`.
 #' @param verbose Whether information should be printed about the HTTP request
 #'    and response. Defaults to `FALSE`.
 #'
@@ -235,8 +235,10 @@ ils <- function(
     }
   }
 
-  limit_maximum_number_of_rows_catalog(irods_zone_overview, limit) |>
-    new_irods_df()
+  if (!is.null(limit)) {
+    irods_zone_overview <- limit_maximum_number_of_rows_catalog(irods_zone_overview, limit)
+  }
+  new_irods_df(irods_zone_overview)
 }
 
 make_ils_stat <- function(lpaths) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,5 +3,5 @@
 
 .onLoad <- function(libname, pkgname) {
   ns <- topenv()
-  ns$.irods_host <- "http://localhost:9001/irods-http-api/0.4.0"
+  ns$.irods_host <- "http://localhost:9001/irods-http-api/0.5.0"
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,5 +3,5 @@
 
 .onLoad <- function(libname, pkgname) {
   ns <- topenv()
-  ns$.irods_host <- "http://localhost:9001/irods-http-api/0.2.0"
+  ns$.irods_host <- "http://localhost:9001/irods-http-api/0.4.0"
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ substitute(create_irods(x), list(x = rirods:::.irods_host))
 ```
 
 ```{r project, eval=is_irods_demo_running(), echo=FALSE}
-eval(substitute(create_irods(x), list(x = rirods:::.irods_host)))
+eval(substitute(create_irods(x), list(x = URLencode(rirods:::.irods_host))))
 ```
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Launch a local demonstration iRODS service (including the HTTP API):
     use_irods_demo("alice", "passWORD")
 
 This will result in the demonstration HTTP API running at
-<http://localhost:9001/irods-http-api/0.2.0>.
+<http://localhost:9001/irods-http-api/0.4.0>.
 
 These Docker containers are designed to easily stand up a
 **DEMONSTRATION** of the iRODS server. It is intended for education and
@@ -49,7 +49,7 @@ To connect to the HTTP API endpoint of your choice, load `rirods`,
 connect with `create_irods()`, and authenticate with your iRODS
 credentials:
 
-    create_irods("http://localhost:9001/irods-http-api/0.2.0")
+    create_irods("http://localhost:9001/irods-http-api/0.4.0")
 
 ### Authentication
 
@@ -70,7 +70,6 @@ session to an iRODS collection. For this, use the `isaveRDS()` command:
 
     # check where we are in the iRODS namespace
     ipwd()
-    #> [1] "/tempZone/home/alice"
 
     # store data in iRODS
     isaveRDS(foo, "foo.rds")
@@ -89,12 +88,6 @@ describes the data object “foo”:
 
     # check if file is stored with associated metadata
     ils(metadata = TRUE)
-    #> 
-    #> ==========
-    #> iRODS Zone
-    #> ==========
-    #>                  logical_path attribute value units
-    #>  /tempZone/home/alice/foo.rds       foo   bar   baz
 
 For more on using metadata, check out `vignette("metadata")`.
 
@@ -105,10 +98,6 @@ current R session, she would use `ireadRDS()`:
 
     # retrieve in native R format
     ireadRDS("foo.rds")
-    #>   x y
-    #> 1 1 x
-    #> 2 8 y
-    #> 3 9 z
 
 ### Other file formats
 
@@ -126,13 +115,6 @@ a file type that can be accessed by other programs. For this, use the
 
     # check whether it is stored
     ils()
-    #> 
-    #> ==========
-    #> iRODS Zone
-    #> ==========
-    #>                  logical_path
-    #>  /tempZone/home/alice/foo.csv
-    #>  /tempZone/home/alice/foo.rds
 
 Later on somebody else might want to download this file again and store
 it locally:
@@ -140,20 +122,6 @@ it locally:
     # retrieve it again later
     iget("foo.csv", "foo.csv")
     read_csv("foo.csv")
-    #> Rows: 3 Columns: 2
-    #> ── Column specification ────────────────────────────────────────────────────────
-    #> Delimiter: ","
-    #> chr (1): y
-    #> dbl (1): x
-    #> 
-    #> ℹ Use `spec()` to retrieve the full column specification for this data.
-    #> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
-    #> # A tibble: 3 × 2
-    #>       x y    
-    #>   <dbl> <chr>
-    #> 1     1 x    
-    #> 2     8 y    
-    #> 3     9 z
 
 ### Query
 
@@ -163,15 +131,9 @@ future projects. Objects can be searched with General Queries and
 
     # look for objects in the home collection with a wildcard `%`
     iquery("SELECT COLL_NAME, DATA_NAME WHERE COLL_NAME LIKE '/tempZone/home/%'")
-    #>              COLL_NAME DATA_NAME
-    #> 1 /tempZone/home/alice   foo.csv
-    #> 2 /tempZone/home/alice   foo.rds
 
     # or for data objects with a name that starts with "foo"
     iquery("SELECT COLL_NAME, DATA_NAME WHERE DATA_NAME LIKE 'foo%'")
-    #>              COLL_NAME DATA_NAME
-    #> 1 /tempZone/home/alice   foo.csv
-    #> 2 /tempZone/home/alice   foo.rds
 
 For more on querying, check out `vignette("metadata")`.
 
@@ -185,7 +147,6 @@ Finally, we can clean up Alice’s home collection:
 
     # check if objects are removed
     ils()
-    #> This collection does not contain any objects or collections.
 
     # close the server
     stop_irods_demo()

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -2,7 +2,7 @@
 .ONESHELL:
 SHELL = /bin/bash
 PATH_MODULES := ../inst/irods_demo/.
-IRODS_MODULES := nginx http icommands catalog
+IRODS_MODULES := nginx http icommands catalog minio
 SPACE = $(eval) $(eval)
 DOCKER_MODULES = $(subst $(SPACE),\|,$(IRODS_MODULES))
 DOCKER_MODULES_REGEX = ".*\($(DOCKER_MODULES)\).*"

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,19 +1,19 @@
 # prepare for CRAN by removing unneeded irods_demo bagage
 .ONESHELL:
 SHELL = /bin/bash
-PATH_MODULES := ../inst/irods_demo
-DOCKER_MODULES := $(addprefix $(PATH_MODULES)/,irods_client_nfsrods irods_client_zone_management_tool metalnx-db metalnx minio-data)
+PATH_MODULES := ../inst/irods_demo/.
+IRODS_MODULES := nginx http icommands catalog
+SPACE = $(eval) $(eval)
+DOCKER_MODULES = $(subst $(SPACE),\|,$(IRODS_MODULES))
+DOCKER_MODULES_REGEX = ".*\($(DOCKER_MODULES)\).*"
 
-all: update remove clean
+.PHONY: update clean
 
-# update modules
+all: update clean
+
 update:
 	git submodule sync --recursive
 	git submodule update --init --force --recursive --remote
-# delete unnecessary docker modules
-remove:
-	rm -rf $(DOCKER_MODULES)
-# remove lines docker-compose
 clean:
-	head -n 65 '$(PATH_MODULES)/docker-compose.yml' > temp.yml
-	mv temp.yml '$(PATH_MODULES)/docker-compose.yml'
+	$(shell find $(PATH_MODULES) -type d ! -regex $(DOCKER_MODULES_REGEX) -exec rm -rf {} +)
+	Rscript extract_irods_services_yaml.R $(DOCKER_MODULES)

--- a/dev/extract_irods_services_yaml.R
+++ b/dev/extract_irods_services_yaml.R
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript --vanilla
+
+args <- commandArgs(trailingOnly = TRUE)
+
+devtools::load_all()
+
+extract_irods_services <- function(services = args[1]) {
+  new_docker_compose_file <- docker_compose_file <- get_docker_yaml()
+  grep_services <- is_irods_service_in_yaml(services, docker_compose_file)
+  new_docker_compose_file[["services"]] <- docker_compose_file[["services"]][grep_services]
+  yaml::write_yaml(new_docker_compose_file,  get_docker_compose_path())
+  invisible(NULL)
+}
+
+extract_irods_services()

--- a/inst/shell_scripts/dry-run-irods-icommands.sh
+++ b/inst/shell_scripts/dry-run-irods-icommands.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-DIR="$(dirname "$(realpath "$0")")"
+DIR=$(realpath $1)
 
 cd $DIR
-cd ../irods_demo
 
 docker exec irods-demo-irods-client-icommands-1 ils

--- a/inst/shell_scripts/iadmin-docker-icommand.sh
+++ b/inst/shell_scripts/iadmin-docker-icommand.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-DIR="$(dirname "$(realpath "$0")")"
-
-cd $DIR
-cd ../irods_demo
+DIR=$(realpath $1)
 
 docker compose up -d irods-client-icommands
-docker exec irods-demo-irods-client-icommands-1 iadmin mkuser "$1" rodsuser
-docker exec irods-demo-irods-client-icommands-1 iadmin moduser "$1" password "$2"
+docker exec irods-demo-irods-client-icommands-1 iadmin mkuser "$2" rodsuser
+docker exec irods-demo-irods-client-icommands-1 iadmin moduser "$2" password "$3"

--- a/man/create_irods.Rd
+++ b/man/create_irods.Rd
@@ -4,10 +4,19 @@
 \alias{create_irods}
 \title{Generate IRODS Configuration File}
 \usage{
-create_irods(host, zone_path = character(1), overwrite = FALSE)
+create_irods(
+  host,
+  irods_home = character(0),
+  zone_path = character(1),
+  overwrite = FALSE
+)
 }
 \arguments{
 \item{host}{URL of host.}
+
+\item{irods_home}{Path to the initial working collection. Once the user is authenticated,
+if no other absolute or relative path has been requested here, it will default
+to \verb{/zoneName/home}.}
 
 \item{zone_path}{Deprecated}
 

--- a/man/icd.Rd
+++ b/man/icd.Rd
@@ -3,23 +3,23 @@
 \name{icd}
 \alias{icd}
 \alias{ipwd}
-\title{Get or Set Current Working Directory in iRODS}
+\title{Get or Set Current Working Directory (Collection) in iRODS}
 \usage{
 icd(dir)
 
 ipwd()
 }
 \arguments{
-\item{dir}{Collection to set as working directory.}
+\item{dir}{Path to set as working collection.}
 }
 \value{
-Invisibly the current directory before the change (same convention as
+Invisibly the current collection before the change (same convention as
 \code{setwd()}).
 }
 \description{
 \code{ipwd()} and \code{icd()} are the iRODS equivalents of \code{\link[=getwd]{getwd()}} and \code{\link[=setwd]{setwd()}}
 respectively. For example, whereas \code{getwd()} returns the current working directory
-in the local system, \code{ipwd()} returns the current working directory in iRODS.
+in the local system, \code{ipwd()} returns the current working collection in iRODS.
 }
 \examples{
 \dontshow{if (is_irods_demo_running()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/ils.Rd
+++ b/man/ils.Rd
@@ -31,7 +31,7 @@ Defaults to \code{FALSE}.}
 
 \item{offset}{Number of records to skip for pagination. Deprecated.}
 
-\item{limit}{Number of records to show per page.}
+\item{limit}{Number of records to show. To show all records, provide \code{NULL}.}
 
 \item{recurse}{Recursively list. Defaults to \code{FALSE}.}
 

--- a/man/imkdir.Rd
+++ b/man/imkdir.Rd
@@ -13,7 +13,7 @@ imkdir(
 }
 \arguments{
 \item{logical_path}{Path to the collection to create, relative to the current
-working directory (see \code{\link[=ipwd]{ipwd()}}).}
+working collection (see \code{\link[=ipwd]{ipwd()}}).}
 
 \item{create_parent_collections}{Whether parent collections should be created
 when necessary. Defaults to \code{FALSE}.}

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.3",
+    "Version": "4.4.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -31,17 +31,17 @@
     },
     "brio": {
       "Package": "brio",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "68bd2b066e1fe780bbf62fc8bcc36de3"
+      "Hash": "c1ee497a6d999947c2c224ae46799b1a"
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.7.5",
+      "Version": "3.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -50,22 +50,22 @@
         "processx",
         "utils"
       ],
-      "Hash": "9f0e4fae4963ba775a5e5c520838c87b"
+      "Hash": "d7e13f49c19103ece9e58ad2d83a7354"
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.2",
+      "Version": "3.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "1216ac65ac55ec0058a6f75d7ca0fd52"
+      "Hash": "b21916dd77a27642b447374a5d30ecf3"
     },
     "crayon": {
       "Package": "crayon",
-      "Version": "1.5.2",
+      "Version": "1.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -73,17 +73,17 @@
         "methods",
         "utils"
       ],
-      "Hash": "e8a1e41acf02548751f45c718d55aa6a"
+      "Hash": "859d96e65ef198fd43e82b9628d593ef"
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.2.1",
+      "Version": "5.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "411ca2c03b1ce5f548345d2fc2685f7a"
+      "Hash": "8f27335f2bcff4d6035edcc82d7d46de"
     },
     "desc": {
       "Package": "desc",
@@ -115,25 +115,25 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.34",
+      "Version": "0.6.37",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "7ede2ee9ea8d3edbf1ca84c1e333ad1a"
+      "Hash": "33698c4b3127fc9f506654607fb73676"
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.23",
+      "Version": "0.24.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "daf4a1246be12c1fa8c7705a0935c1a0"
+      "Hash": "a1066cbc05caee9a4bf6d90f194ff4da"
     },
     "fansi": {
       "Package": "fansi",
@@ -149,14 +149,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.3",
+      "Version": "1.6.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
+      "Hash": "15aeb8c27f5ea5161f9f6a641fafd93a"
     },
     "glue": {
       "Package": "glue",
@@ -171,7 +171,7 @@
     },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.0.0",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -188,7 +188,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "e2b30f1fc039a0bab047dd52bb20ef71"
+      "Hash": "10d93e97faad6b629301bb3a2fd23378"
     },
     "jsonlite": {
       "Package": "jsonlite",
@@ -225,13 +225,13 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.1.1",
+      "Version": "2.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "2a0dc8c6adfb6f032e4d4af82d258ab5"
+      "Hash": "c62edf62de70cadf40553e10c739049d"
     },
     "pillar": {
       "Package": "pillar",
@@ -252,7 +252,7 @@
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.4.3",
+      "Version": "1.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -263,7 +263,7 @@
         "desc",
         "processx"
       ],
-      "Hash": "c0143443203205e6a2760ce553dafc24"
+      "Hash": "a29e8e134a460a01e0ca67a4763c595b"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -277,24 +277,25 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.3.4",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
-        "crayon",
         "desc",
         "fs",
         "glue",
+        "lifecycle",
         "methods",
         "pkgbuild",
+        "processx",
         "rlang",
         "rprojroot",
         "utils",
         "withr"
       ],
-      "Hash": "876c618df5ae610be84356d5d7a5d124"
+      "Hash": "2ec30ffbeec83da57655b850cf2d3e0e"
     },
     "praise": {
       "Package": "praise",
@@ -305,7 +306,7 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.8.3",
+      "Version": "3.8.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -314,18 +315,18 @@
         "ps",
         "utils"
       ],
-      "Hash": "82d48b1aec56084d9438dbf98087a7e9"
+      "Hash": "0c90a7d71988856bad2a2a45dd871bb9"
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.7.6",
+      "Version": "1.7.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "dd2b9319ee0656c8acf45c7f40c59de7"
+      "Hash": "878b467580097e9c383acbb16adab57a"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -349,24 +350,24 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.5",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "32c3f93e8360f667ca5863272ec8ba6a"
+      "Hash": "397b7b2a265bc5a7a06852524dabae20"
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.3",
+      "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "42548638fae05fd9a9b5f3f437fbbbe2"
+      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -387,7 +388,7 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.2.1",
+      "Version": "3.2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -412,7 +413,7 @@
         "waldo",
         "withr"
       ],
-      "Hash": "4767a686ebe986e6cb01d075b3f09729"
+      "Hash": "3f6e7e5e2220856ff865e4834766bf2b"
     },
     "tibble": {
       "Package": "tibble",
@@ -459,25 +460,24 @@
     },
     "waldo": {
       "Package": "waldo",
-      "Version": "0.5.2",
+      "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
         "diffobj",
-        "fansi",
         "glue",
         "methods",
         "rematch2",
         "rlang",
         "tibble"
       ],
-      "Hash": "c7d3fd6d29ab077cbac8f0e2751449e6"
+      "Hash": "16aa934a49658677d8041df9017329b9"
     },
     "withr": {
       "Package": "withr",
-      "Version": "3.0.0",
+      "Version": "3.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -485,7 +485,7 @@
         "grDevices",
         "graphics"
       ],
-      "Hash": "d31b6c62c10dcf11ec530ca6b0dd5d35"
+      "Hash": "07909200e8bbe90426fbfeb73e1e27aa"
     }
   }
 }

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.5"
+  version <- "1.0.7"
   attr(version, "sha") <- NULL
 
   # the project directory

--- a/rirods.Rproj
+++ b/rirods.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d4873443-6601-4000-b3b3-92125b1bfb69
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-docker-yaml.R
+++ b/tests/testthat/test-docker-yaml.R
@@ -1,0 +1,19 @@
+test_that("docker compose yaml can be found and loaded", {
+  skip_on_os("windows")
+  path <- get_docker_compose_path()
+  expect_equal(path,
+               system.file("irods_demo/docker-compose.yml", package = "rirods"))
+  expect_vector(get_docker_yaml())
+  expect_equal(any(is_irods_service_in_yaml("nginx", get_docker_yaml())), TRUE)
+  ref <- list(c(
+    "irods-catalog",
+    "irods-catalog-provider",
+    "irods-catalog-consumer",
+    "irods-client-icommands",
+    "irods-client-http-api",
+    "nginx-reverse-proxy"
+  )) |> setNames("irods-demo")
+  expect_equal(extract_irods_services_names(c(
+    "nginx", "http-api", "icommands", "catalog"
+  )), ref)
+})


### PR DESCRIPTION
To address issue #51 
This PR sets "/zoneName/home" as the starting point for checking whether a path exists and allows the user to customize the starting point when loging in (e.g. "mariana" for /zoneName/home/mariana", or "/zoneName/home/project/input").

`ils()` now also has the option of not limiting the number of entries. Because it was imposing the "max_number_of_rows_per_catalog_query" of the HTTP API config (but this number was not sent to the API, it was used to truncate the output of `ils()`), when `ils()` was called to check the existing paths, it only listed 15 elements (the default value). As a result, any item outside of the first 15 elements was evaluated as not existing and it was not possible to do `icd()` on it. I would go as far as ignoring the HTTP API config in this case, since the truncating is done post-hoc anyways.

Still to do:
- [ ] Adapt tests
- [ ] Fix other bugs (issues with `stat=TRUE` and `permissions=TRUE` that I was finding in `ils()` and still have to investigate further)